### PR TITLE
Ensure that version.h is installed alongside lib

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -261,8 +261,7 @@ pub fn build(b: *std.Build) void {
         .exclude_extensions = &.{ ".c", ".h.in" },
     });
 
-    const install_version = b.addInstallFile(version_header.getOutput(), "include/pulse/version.h");
-    b.getInstallStep().dependOn(&install_version.step);
+    lib.installConfigHeader(version_header, .{ .install_dir = .header, .dest_rel_path = "pulse/version.h" });
     b.installArtifact(lib);
 }
 


### PR DESCRIPTION
Change installation method for the version header to be recognized alongside other headers.

Current implementation does not actually install it as part of the dependency, only populates an output location.