### PR TITLE
nonthreaded mainloop support

### DIFF
--- a/bindings.zig
+++ b/bindings.zig
@@ -1004,7 +1004,36 @@ pub const subscription_mask_t = enum(c_uint) {
     CARD = 512,
     ALL = 767,
 };
-pub const mainloop = opaque {};
+pub const mainloop = opaque {
+    pub fn new() error{OutOfMemory}!*mainloop {
+        return pa_mainloop_new() orelse return error.OutOfMemory;
+    }
+    extern fn pa_mainloop_new() ?*mainloop;
+    pub const free = pa_mainloop_free;
+    extern fn pa_mainloop_free(m: ?*mainloop) void;
+    pub const prepare = pa_mainloop_prepare;
+    extern fn pa_mainloop_prepare(m: ?*mainloop, timeout: c_int) c_int;
+    pub const poll = pa_mainloop_poll;
+    extern fn pa_mainloop_poll(m: ?*mainloop) c_int;
+    pub const dispatch = pa_mainloop_dispatch;
+    extern fn pa_mainloop_dispatch(m: ?*mainloop) c_int;
+    pub const get_retval = pa_mainloop_get_retval;
+    extern fn pa_mainloop_get_retval(m: ?*const mainloop) c_int;
+    pub fn iterate(m: *mainloop, block: enum(u1) { nonblocking = 0, blocking = 1 }, quit_result: ?*c_int) c_int {
+        return pa_mainloop_iterate(m, @intFromEnum(block), quit_result);
+    }
+    extern fn pa_mainloop_iterate(m: ?*mainloop, block: c_int, retval: [*c]c_int) c_int;
+    pub const run = pa_mainloop_run;
+    extern fn pa_mainloop_run(m: ?*mainloop, retval: [*c]c_int) c_int;
+    pub const get_api = pa_mainloop_get_api;
+    extern fn pa_mainloop_get_api(m: ?*mainloop) *mainloop_api;
+    pub const quit = pa_mainloop_quit;
+    extern fn pa_mainloop_quit(m: ?*mainloop, retval: c_int) void;
+    pub const wakeup = pa_mainloop_wakeup;
+    extern fn pa_mainloop_wakeup(m: ?*mainloop) void;
+    pub const set_poll_func = pa_mainloop_set_poll_func;
+    extern fn pa_mainloop_set_poll_func(m: ?*mainloop, poll_func: poll_func, userdata: ?*anyopaque) void;
+};
 pub const subscription_event_type_t = enum(c_uint) {
     SINK = 0,
     SOURCE = 1,
@@ -1149,18 +1178,6 @@ extern fn pa_utf8_filter(str: [*c]const u8) [*c]u8;
 extern fn pa_ascii_filter(str: [*c]const u8) [*c]u8;
 extern fn pa_utf8_to_locale(str: [*c]const u8) [*c]u8;
 extern fn pa_locale_to_utf8(str: [*c]const u8) [*c]u8;
-extern fn pa_mainloop_new() ?*mainloop;
-extern fn pa_mainloop_free(m: ?*mainloop) void;
-extern fn pa_mainloop_prepare(m: ?*mainloop, timeout: c_int) c_int;
-extern fn pa_mainloop_poll(m: ?*mainloop) c_int;
-extern fn pa_mainloop_dispatch(m: ?*mainloop) c_int;
-extern fn pa_mainloop_get_retval(m: ?*const mainloop) c_int;
-extern fn pa_mainloop_iterate(m: ?*mainloop, block: c_int, retval: [*c]c_int) c_int;
-extern fn pa_mainloop_run(m: ?*mainloop, retval: [*c]c_int) c_int;
-extern fn pa_mainloop_get_api(m: ?*mainloop) *mainloop_api;
-extern fn pa_mainloop_quit(m: ?*mainloop, retval: c_int) void;
-extern fn pa_mainloop_wakeup(m: ?*mainloop) void;
-extern fn pa_mainloop_set_poll_func(m: ?*mainloop, poll_func: poll_func, userdata: ?*anyopaque) void;
 extern fn pa_signal_init(api: *mainloop_api) c_int;
 extern fn pa_signal_done() void;
 extern fn pa_signal_new(sig: c_int, callback: signal_cb_t, userdata: ?*anyopaque) ?*signal_event;

--- a/build.zig
+++ b/build.zig
@@ -268,10 +268,10 @@ pub fn build(b: *std.Build) void {
     });
     bindings.linkLibrary(lib);
 
-    const sine_exe = b.addExecutable(.{
-        .name = "sine",
+    const sine_threaded_exe = b.addExecutable(.{
+        .name = "sine-threaded",
         .root_module = b.createModule(.{
-            .root_source_file = b.path("example/sine.zig"),
+            .root_source_file = b.path("example/sine-threaded.zig"),
             .target = target,
             .optimize = optimize,
             .imports = &.{
@@ -282,7 +282,23 @@ pub fn build(b: *std.Build) void {
             },
         }),
     });
-    b.installArtifact(sine_exe);
+    b.installArtifact(sine_threaded_exe);
+
+    const sine_mainloop_exe = b.addExecutable(.{
+        .name = "sine-mainloop",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("example/sine-mainloop.zig"),
+            .target = target,
+            .optimize = optimize,
+            .imports = &.{
+                .{
+                    .name = "pulseaudio",
+                    .module = bindings,
+                },
+            },
+        }),
+    });
+    b.installArtifact(sine_mainloop_exe);
 }
 
 fn have(b: bool) ?c_int {

--- a/example/sine-mainloop.zig
+++ b/example/sine-mainloop.zig
@@ -1,0 +1,139 @@
+//! An example of using pulseaudio's mainloop API to render a sine wave.
+const std = @import("std");
+const pa = @import("pulseaudio");
+const sine = @import("sine.zig");
+
+pub fn main() !void {
+    const main_loop = try pa.mainloop.new();
+    defer main_loop.free();
+
+    const props = try pa.proplist.new();
+    defer props.free();
+
+    try props.sets("media.role", "music");
+    try props.sets("media.software", "my cool app");
+    try props.sets("media.title", "song title");
+    try props.sets("media.artist", "song artist");
+
+    const context = try pa.context.new_with_proplist(main_loop.get_api(), "sine example", props);
+    defer context.unref();
+
+    try context.connect(null, .{}, null);
+    defer context.disconnect();
+
+    {
+        var state: ?pa.context.state_t = null;
+        while (true) {
+            const new_state = context.get_state();
+            if (new_state != state) {
+                state = new_state;
+                std.log.info("context state: {s}", .{@tagName(new_state)});
+                switch (new_state) {
+                    .UNCONNECTED, .CONNECTING, .AUTHORIZING, .SETTING_NAME => {},
+                    .READY => break,
+                    .FAILED => {
+                        const errno = context.errno();
+                        errExit("connect context failed, errno={} ({s})", .{ errno, pa.strerror(errno) });
+                    },
+                    .TERMINATED => unreachable,
+                }
+            }
+            if (main_loop.iterate(.blocking, null) < 0) {
+                const errno = context.errno();
+                errExit("connect context failed, errno={} ({s})", .{ errno, pa.strerror(errno) });
+            }
+        }
+    }
+
+    var sine_phase: f32 = 0;
+
+    {
+        const sample_spec: pa.sample_spec = .{
+            .format = .FLOAT32LE,
+            .rate = 48000,
+            .channels = 2,
+        };
+        const channel_map: pa.channel_map = .{
+            .channels = 2,
+            .map = .{ .LEFT, .RIGHT } ++ .{.INVALID} ** 30,
+        };
+        const stream = try pa.stream.new_with_proplist(context, "main stream", &sample_spec, &channel_map, props);
+
+        stream.set_write_callback(streamWriteCallback, &sine_phase);
+
+        try stream.connect_playback(null, null, .{
+            .START_CORKED = true,
+            .AUTO_TIMING_UPDATE = true,
+            .INTERPOLATE_TIMING = true,
+            .FIX_FORMAT = true,
+            .FIX_RATE = true,
+            .FIX_CHANNELS = true,
+        }, null, null);
+
+        var state: ?pa.stream.state_t = null;
+        while (true) {
+            const new_state = stream.get_state();
+            if (new_state != state) {
+                std.log.info("stream state: {s}", .{@tagName(new_state)});
+                state = new_state;
+                switch (new_state) {
+                    .UNCONNECTED, .CREATING => {},
+                    .READY => break,
+                    .FAILED => {
+                        const errno = context.errno();
+                        errExit("connect stream failed, errno={} ({s})", .{ errno, pa.strerror(errno) });
+                    },
+                    .TERMINATED => unreachable,
+                }
+            }
+
+            if (main_loop.iterate(.blocking, null) < 0) {
+                const errno = context.errno();
+                errExit("mainloop iterate failed while connecting stream, errno={} ({s})", .{ errno, pa.strerror(errno) });
+            }
+        }
+
+        const fixed_sample_spec = stream.get_sample_spec();
+        const fixed_channel_map = stream.get_channel_map();
+        std.log.info("fixed_sample_spec={}-channel {}Hz {s}", .{
+            fixed_sample_spec.channels,
+            fixed_sample_spec.rate,
+            @tagName(fixed_sample_spec.format),
+        });
+        for (fixed_channel_map.map[0..fixed_channel_map.channels], 0..) |channel, i| {
+            std.log.info("fixed_channel_map[{d}]={s}", .{ i, @tagName(channel) });
+        }
+        const op = try stream.cork(0, null, null);
+        op.unref();
+    }
+
+    var quit_result: c_int = undefined;
+    if (0 != main_loop.run(&quit_result)) {
+        const errno = context.errno();
+        errExit("mainloop failure, errno={} ({s})", .{ errno, pa.strerror(errno) });
+    }
+    std.debug.assert(quit_result == 0);
+}
+
+fn streamWriteCallback(stream: *pa.stream, requested_bytes: usize, userdata: ?*anyopaque) callconv(.c) void {
+    const sine_phase_ref: *f32 = @ptrCast(@alignCast(userdata.?));
+    const sample_spec = stream.get_sample_spec();
+    std.log.info("requested bytes: {d}", .{requested_bytes});
+    var remaining_bytes = requested_bytes;
+    while (remaining_bytes > 0) {
+        var ptr_len: usize = remaining_bytes;
+        var opt_ptr: ?[*]u8 = null;
+        stream.begin_write(@ptrCast(&opt_ptr), &ptr_len) catch @panic("unhandleable error");
+        const ptr = opt_ptr orelse @panic("unhandleable error");
+        const write_len = @min(ptr_len, remaining_bytes);
+        sine.render(sine_phase_ref, sample_spec.*, ptr, write_len);
+        stream.write(ptr, write_len, null, 0, .RELATIVE) catch @panic("unhandleable error");
+        remaining_bytes -= write_len;
+        std.log.info("wrote {d} bytes, {d} remaining", .{ write_len, remaining_bytes });
+    }
+}
+
+fn errExit(comptime fmt: []const u8, args: anytype) noreturn {
+    std.log.err(fmt, args);
+    std.process.exit(1);
+}

--- a/example/sine-threaded.zig
+++ b/example/sine-threaded.zig
@@ -1,0 +1,157 @@
+//! An example of using pulseaudio's threaded mainloop API to render a sine wave.
+const std = @import("std");
+const pa = @import("pulseaudio");
+const sine = @import("sine.zig");
+
+const Pulse = struct {
+    state: pa.context.state_t,
+    stream_state: pa.stream.state_t,
+    main_loop: *pa.threaded_mainloop,
+    sine_phase: f32,
+};
+
+pub fn main() !void {
+    const main_loop = try pa.threaded_mainloop.new();
+    defer main_loop.free();
+
+    const props = try pa.proplist.new();
+    defer props.free();
+
+    try props.sets("media.role", "music");
+    try props.sets("media.software", "my cool app");
+    try props.sets("media.title", "song title");
+    try props.sets("media.artist", "song artist");
+
+    const context = try pa.context.new_with_proplist(main_loop.get_api(), "sine example", props);
+    defer context.unref();
+
+    try context.connect(null, .{}, null);
+    defer context.disconnect();
+
+    var pulse: Pulse = .{
+        .state = .UNCONNECTED,
+        .stream_state = .UNCONNECTED,
+        .main_loop = main_loop,
+        .sine_phase = 0,
+    };
+    context.set_state_callback(contextStateCallback, &pulse);
+
+    try main_loop.start();
+    defer main_loop.stop();
+
+    {
+        // Block until ready.
+        main_loop.lock();
+        defer main_loop.unlock();
+
+        while (true) {
+            main_loop.wait();
+            switch (pulse.state) {
+                .READY => break,
+                .FAILED => return error.Failed,
+                .TERMINATED => return error.Terminated,
+                else => continue,
+            }
+        }
+    }
+
+    {
+        // Open output stream.
+        main_loop.lock();
+        defer main_loop.unlock();
+
+        const sample_spec: pa.sample_spec = .{
+            .format = .FLOAT32LE,
+            .rate = 48000,
+            .channels = 2,
+        };
+        const channel_map: pa.channel_map = .{
+            .channels = 2,
+            .map = .{ .LEFT, .RIGHT } ++ .{.INVALID} ** 30,
+        };
+        const stream = try pa.stream.new_with_proplist(context, "main stream", &sample_spec, &channel_map, props);
+
+        stream.set_state_callback(streamStateCallback, &pulse);
+        stream.set_write_callback(streamWriteCallback, &pulse);
+
+        try stream.connect_playback(null, null, .{
+            .START_CORKED = true,
+            .AUTO_TIMING_UPDATE = true,
+            .INTERPOLATE_TIMING = true,
+            .FIX_FORMAT = true,
+            .FIX_RATE = true,
+            .FIX_CHANNELS = true,
+        }, null, null);
+
+        while (true) {
+            main_loop.wait();
+            switch (pulse.stream_state) {
+                .READY => break,
+                .FAILED => return error.StreamFailed,
+                .TERMINATED => return error.StreamTerminated,
+                else => continue,
+            }
+        }
+
+        const fixed_sample_spec = stream.get_sample_spec();
+        const fixed_channel_map = stream.get_channel_map();
+        std.log.info("fixed_sample_spec={}-channel {}Hz {s}", .{
+            fixed_sample_spec.channels,
+            fixed_sample_spec.rate,
+            @tagName(fixed_sample_spec.format),
+        });
+        for (fixed_channel_map.map[0..fixed_channel_map.channels], 0..) |channel, i| {
+            std.log.info("fixed_channel_map[{d}]={s}", .{ i, @tagName(channel) });
+        }
+
+        const op = try stream.cork(0, null, null);
+        op.unref();
+
+        while (true) {
+            main_loop.wait();
+            switch (pulse.stream_state) {
+                .FAILED => return error.StreamFailed,
+                .TERMINATED => return error.StreamTerminated,
+                else => continue,
+            }
+        }
+    }
+}
+
+fn contextStateCallback(context: *pa.context, userdata: ?*anyopaque) callconv(.c) void {
+    const pulse: *Pulse = @ptrCast(@alignCast(userdata));
+    pulse.state = context.get_state();
+    std.log.info("context state: {s}", .{@tagName(pulse.state)});
+    switch (pulse.state) {
+        .UNCONNECTED, .CONNECTING, .AUTHORIZING, .SETTING_NAME => return,
+        .READY, .FAILED, .TERMINATED => pulse.main_loop.signal(0),
+    }
+}
+
+fn streamStateCallback(stream: *pa.stream, userdata: ?*anyopaque) callconv(.c) void {
+    const pulse: *Pulse = @ptrCast(@alignCast(userdata));
+    pulse.stream_state = stream.get_state();
+    std.log.info("stream state: {s}", .{@tagName(pulse.stream_state)});
+    switch (pulse.stream_state) {
+        .UNCONNECTED, .CREATING => return,
+        .READY, .FAILED, .TERMINATED => pulse.main_loop.signal(0),
+    }
+}
+
+fn streamWriteCallback(stream: *pa.stream, requested_bytes: usize, userdata: ?*anyopaque) callconv(.c) void {
+    const pulse: *Pulse = @ptrCast(@alignCast(userdata));
+    const sample_spec = stream.get_sample_spec();
+    std.log.info("requested bytes: {d}", .{requested_bytes});
+    var remaining_bytes = requested_bytes;
+    while (remaining_bytes > 0) {
+        var ptr_len: usize = remaining_bytes;
+        var opt_ptr: ?[*]u8 = null;
+        stream.begin_write(@ptrCast(&opt_ptr), &ptr_len) catch @panic("unhandleable error");
+        const ptr = opt_ptr orelse @panic("unhandleable error");
+        const write_len = @min(ptr_len, remaining_bytes);
+        sine.render(&pulse.sine_phase, sample_spec.*, ptr, write_len);
+        stream.write(ptr, write_len, null, 0, .RELATIVE) catch @panic("unhandleable error");
+        remaining_bytes -= write_len;
+        std.log.info("wrote {d} bytes, {d} remaining", .{ write_len, remaining_bytes });
+    }
+}

--- a/example/sine.zig
+++ b/example/sine.zig
@@ -1,165 +1,12 @@
 const std = @import("std");
 const pa = @import("pulseaudio");
 
-const Pulse = struct {
-    state: pa.context.state_t,
-    stream_state: pa.stream.state_t,
-    main_loop: *pa.threaded_mainloop,
-    sine_phase: f32,
-};
-
-pub fn main() !void {
-    const main_loop = try pa.threaded_mainloop.new();
-    defer main_loop.free();
-
-    const props = try pa.proplist.new();
-    defer props.free();
-
-    try props.sets("media.role", "music");
-    try props.sets("media.software", "my cool app");
-    try props.sets("media.title", "song title");
-    try props.sets("media.artist", "song artist");
-
-    const context = try pa.context.new_with_proplist(main_loop.get_api(), "sine example", props);
-    defer context.unref();
-
-    try context.connect(null, .{}, null);
-    defer context.disconnect();
-
-    var pulse: Pulse = .{
-        .state = .UNCONNECTED,
-        .stream_state = .UNCONNECTED,
-        .main_loop = main_loop,
-        .sine_phase = 0,
-    };
-    context.set_state_callback(contextStateCallback, &pulse);
-
-    try main_loop.start();
-    defer main_loop.stop();
-
-    {
-        // Block until ready.
-        main_loop.lock();
-        defer main_loop.unlock();
-
-        while (true) {
-            main_loop.wait();
-            switch (pulse.state) {
-                .READY => break,
-                .FAILED => return error.Failed,
-                .TERMINATED => return error.Terminated,
-                else => continue,
-            }
-        }
-    }
-
-    {
-        // Open output stream.
-        main_loop.lock();
-        defer main_loop.unlock();
-
-        const sample_spec: pa.sample_spec = .{
-            .format = .FLOAT32LE,
-            .rate = 48000,
-            .channels = 2,
-        };
-        const channel_map: pa.channel_map = .{
-            .channels = 2,
-            .map = .{ .LEFT, .RIGHT } ++ .{.INVALID} ** 30,
-        };
-        const stream = try pa.stream.new_with_proplist(context, "main stream", &sample_spec, &channel_map, props);
-
-        stream.set_state_callback(streamStateCallback, &pulse);
-        stream.set_write_callback(streamWriteCallback, &pulse);
-
-        try stream.connect_playback(null, null, .{
-            .START_CORKED = true,
-            .AUTO_TIMING_UPDATE = true,
-            .INTERPOLATE_TIMING = true,
-            .FIX_FORMAT = true,
-            .FIX_RATE = true,
-            .FIX_CHANNELS = true,
-        }, null, null);
-
-        while (true) {
-            main_loop.wait();
-            switch (pulse.stream_state) {
-                .READY => break,
-                .FAILED => return error.StreamFailed,
-                .TERMINATED => return error.StreamTerminated,
-                else => continue,
-            }
-        }
-
-        const fixed_sample_spec = stream.get_sample_spec();
-        const fixed_channel_map = stream.get_channel_map();
-        std.log.info("fixed_sample_spec={}-channel {}Hz {s}", .{
-            fixed_sample_spec.channels,
-            fixed_sample_spec.rate,
-            @tagName(fixed_sample_spec.format),
-        });
-        for (fixed_channel_map.map[0..fixed_channel_map.channels], 0..) |channel, i| {
-            std.log.info("fixed_channel_map[{d}]={s}", .{ i, @tagName(channel) });
-        }
-
-        const op = try stream.cork(0, null, null);
-        op.unref();
-
-        while (true) {
-            main_loop.wait();
-            switch (pulse.stream_state) {
-                .FAILED => return error.StreamFailed,
-                .TERMINATED => return error.StreamTerminated,
-                else => continue,
-            }
-        }
-    }
-}
-
-fn contextStateCallback(context: *pa.context, userdata: ?*anyopaque) callconv(.c) void {
-    const pulse: *Pulse = @ptrCast(@alignCast(userdata));
-    pulse.state = context.get_state();
-    std.log.info("context state: {s}", .{@tagName(pulse.state)});
-    switch (pulse.state) {
-        .UNCONNECTED, .CONNECTING, .AUTHORIZING, .SETTING_NAME => return,
-        .READY, .FAILED, .TERMINATED => pulse.main_loop.signal(0),
-    }
-}
-
-fn streamStateCallback(stream: *pa.stream, userdata: ?*anyopaque) callconv(.c) void {
-    const pulse: *Pulse = @ptrCast(@alignCast(userdata));
-    pulse.stream_state = stream.get_state();
-    std.log.info("stream state: {s}", .{@tagName(pulse.stream_state)});
-    switch (pulse.stream_state) {
-        .UNCONNECTED, .CREATING => return,
-        .READY, .FAILED, .TERMINATED => pulse.main_loop.signal(0),
-    }
-}
-
-fn streamWriteCallback(stream: *pa.stream, requested_bytes: usize, userdata: ?*anyopaque) callconv(.c) void {
-    const pulse: *Pulse = @ptrCast(@alignCast(userdata));
-    const sample_spec = stream.get_sample_spec();
-    std.log.info("requested bytes: {d}", .{requested_bytes});
-    var remaining_bytes = requested_bytes;
-    while (remaining_bytes > 0) {
-        var ptr_len: usize = remaining_bytes;
-        var opt_ptr: ?[*]u8 = null;
-        stream.begin_write(@ptrCast(&opt_ptr), &ptr_len) catch @panic("unhandleable error");
-        const ptr = opt_ptr orelse @panic("unhandleable error");
-        const write_len = @min(ptr_len, remaining_bytes);
-        renderSine(&pulse.sine_phase, sample_spec.*, ptr, write_len);
-        stream.write(ptr, write_len, null, 0, .RELATIVE) catch @panic("unhandleable error");
-        remaining_bytes -= write_len;
-        std.log.info("wrote {d} bytes, {d} remaining", .{ write_len, remaining_bytes });
-    }
-}
-
-fn renderSine(sine_phase_ref: *f32, sample_spec: pa.sample_spec, buffer: [*]u8, len: usize) void {
+pub fn render(sine_phase_ref: *f32, sample_spec: pa.sample_spec, buffer: [*]u8, len: usize) void {
     const sample_len = sample_spec.format.sample_size();
     const frame_len = sample_len * sample_spec.channels;
     var offset: usize = 0;
     while (offset + frame_len <= len) {
-        const sample = sampleFromF32(sample_spec.format, nextSineSample(sine_phase_ref, sample_spec.rate));
+        const sample = sampleFromF32(sample_spec.format, nextSample(sine_phase_ref, sample_spec.rate));
         for (0..sample_spec.channels) |_| {
             @memcpy((buffer + offset)[0..sample_len], sample.slice());
             offset += sample_len;
@@ -167,7 +14,7 @@ fn renderSine(sine_phase_ref: *f32, sample_spec: pa.sample_spec, buffer: [*]u8, 
     }
 }
 
-fn nextSineSample(sine_phase_ref: *f32, sample_rate: u32) f32 {
+fn nextSample(sine_phase_ref: *f32, sample_rate: u32) f32 {
     const pitch: f32 = 440;
     const volume: f32 = 0.3;
 


### PR DESCRIPTION
This moves the mainloop bindings into the `mainloop` scope like the other "object-based" functions have been. This also copies the sine example so now there is both threaded and non-threaded mainloop variations.