### PR TITLE
stream: fix array out-of-bounds in stream_get_timing_info_callback

### DIFF
--- a/src/pulse/stream.c
+++ b/src/pulse/stream.c
@@ -1917,7 +1917,10 @@ static void stream_get_timing_info_callback(pa_pdispatch *pd, uint32_t command, 
              * total correction.*/
             for (n = 0, j = o->stream->current_write_index_correction+1;
                  n < PA_MAX_WRITE_INDEX_CORRECTIONS;
-                 n++, j = (j + 1) % PA_MAX_WRITE_INDEX_CORRECTIONS) {
+                 n++, j++) {
+
+                /* First fix up the index to be within the array */
+                j = j % PA_MAX_WRITE_INDEX_CORRECTIONS;
 
                 /* Step over invalid data or out-of-date data */
                 if (!o->stream->write_index_corrections[j].valid ||


### PR DESCRIPTION
fixes: #5

I fixed and merged an array out-of-bounds access upstream here: https://gitlab.freedesktop.org/pulseaudio/pulseaudio/-/merge_requests/850

I've cherry-picked the same change in this PR.

> P.S. I've also been using this patch in the new linux client for Tuple I've been working on the past couple months