### PR TITLE
bindings: make dev parameter nullable in pa_stream_connect_record

### DIFF
--- a/bindings.zig
+++ b/bindings.zig
@@ -651,7 +651,7 @@ pub const stream = opaque {
     }
     extern fn pa_stream_connect_playback(s: *stream, dev: ?[*:0]const u8, attr: ?*const buffer_attr, flags: flags_t, volume: ?*const cvolume, sync_stream: ?*stream) c_int;
     pub const connect_record = pa_stream_connect_record;
-    extern fn pa_stream_connect_record(s: *stream, dev: [*:0]const u8, attr: ?*const buffer_attr, flags: flags_t) c_int;
+    extern fn pa_stream_connect_record(s: *stream, dev: ?[*:0]const u8, attr: ?*const buffer_attr, flags: flags_t) c_int;
     pub const disconnect = pa_stream_disconnect;
     extern fn pa_stream_disconnect(s: *stream) c_int;
     pub fn begin_write(p: *stream, data: *?*anyopaque, nbytes: *usize) Error!void {


### PR DESCRIPTION
The C API allows `NULL` to be passed for the `dev` parameter to let the server choose the source :
`        const char *dev               /*< Name of the source to connect to, or NULL to let the server decide */,
`